### PR TITLE
Fix multiple row insertion bug

### DIFF
--- a/ABStaticTableViewController.m
+++ b/ABStaticTableViewController.m
@@ -128,12 +128,12 @@
 
 - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
 {
+    [self insertRowsAtIndexPaths:indexPaths];
     [self.tableView beginUpdates];
     NSMutableArray *ips = [NSMutableArray array];
     for (NSIndexPath *ip in indexPaths)
         [ips addObject:[self recoverRow:ip]];
     [self.tableView insertRowsAtIndexPaths:ips withRowAnimation:animation];
-    [self insertRowsAtIndexPaths:indexPaths];
     [self.tableView endUpdates];
 }
 


### PR DESCRIPTION
It has been a while. Not sure this code is being maintained.

There is a crash bug if you are inserting multiple rows with animation.  Check out the modified sample to reproduce the bug *(search for "SEE HERE" in the codebase)*.

This PR fixes this issue.

[ABStaticTableViewController.zip](https://github.com/k06a/ABStaticTableViewController/files/681409/ABStaticTableViewController.zip)
